### PR TITLE
Allow index to be stored in the bucket root

### DIFF
--- a/manage-packages
+++ b/manage-packages
@@ -91,16 +91,23 @@ def aws_bucket():
         _cached_bucket = conn.get_bucket(BUCKET_NAME)
     return _cached_bucket
 
+
 def push_to_s3(key, file):
     k = Key(aws_bucket())
     k.key = key
     k.set_contents_from_filename(getattr(file, 'name', file))
     k.make_public()
 
+
+def get_packages_path():
+    return 'packages/' if not CHEESESHOP_DIR else '%s/packages' % CHEESESHOP_DIR
+
+
 def upload_to_cheeseshop(packages=[], requirement=None, upgrade=False):
     if requirement is None: # Just an alternate way to update the index...
         build_cheeseshop_index()
 
+    prefix = get_packages_path()
     bucket = aws_bucket()
 
     freeze = tempfile.NamedTemporaryFile().name
@@ -118,7 +125,6 @@ def upload_to_cheeseshop(packages=[], requirement=None, upgrade=False):
     result = subprocess.check_output('cd %s ; ls' % pypi, shell=True).strip()
 
     # Find out current packages
-    prefix = "%s/packages/" % CHEESESHOP_DIR
     packages = [key.name[len(prefix):] for key in bucket.list()
                 if key.name.startswith(prefix)]
 
@@ -126,16 +132,17 @@ def upload_to_cheeseshop(packages=[], requirement=None, upgrade=False):
         if "/" in package: continue # cd had output
         if not is_compressed(package): continue # Junk file
         if not upgrade and package in packages:
-            print "Package %s already in %s" % (package, CHEESESHOP_DIR)
+            print "Package %s already in %s" % (package,
+                                                CHEESESHOP_DIR or BUCKET_NAME)
             continue # Already uploaded
-        print "Uploading %s to %s" % (package, CHEESESHOP_DIR)
-        push_to_s3("%s/packages/%s" % (CHEESESHOP_DIR, package),
+        print "Uploading %s to %s" % (package, CHEESESHOP_DIR or BUCKET_NAME)
+        push_to_s3("%s%s" % (prefix, package),
                    "%s/%s" % (pypi, package))
     build_cheeseshop_index()
 
 def build_cheeseshop_index():
     bucket = aws_bucket()
-    prefix = "%s/packages/" % CHEESESHOP_DIR
+    prefix = get_packages_path()
 
     # Build index.html
     packages = [key.name[len(prefix):] for key in bucket.list()
@@ -149,11 +156,13 @@ def build_cheeseshop_index():
     links = '\n'.join(links)
 
     k = Key(bucket)
-    k.key = "%s/index.html" % CHEESESHOP_DIR
+    k.key = (('%s/index.html' % CHEESESHOP_DIR)
+             if CHEESESHOP_DIR else 'index.html')
     k.set_metadata('Content-Type', 'text/html')
     k.set_contents_from_string(html % links)
     k.make_public()
 
-    print "Index for %s has been updated." % CHEESESHOP_DIR
+    print "Index for %s has been updated." % (CHEESESHOP_DIR or BUCKET_NAME)
+
 
 dispatch()


### PR DESCRIPTION
When no `CHEESESHOP_DIR` is specified (i.e. is falsey), store the index and
packages directory in the bucket root.
