### PR TITLE
Tweaks for pip mirroring at sightmachine

### DIFF
--- a/manage-packages
+++ b/manage-packages
@@ -111,7 +111,10 @@ def upload_to_cheeseshop(packages=[], requirement=None, upgrade=False):
     compiled_packages = [p for p in packages if is_compressed(p)]
     packages = [p for p in packages if p not in compiled_packages]
     pkgs = " ".join(packages)
-    subprocess.call("pip install -d %s %s %s" % (pypi, sreq, pkgs), shell=True)
+    opts = "--no-use-wheel --no-binary :all:"
+    download_command = "pip install %s -d %s %s %s" % (opts, pypi, sreq, pkgs)
+    if subprocess.call(download_command, shell=True) != 0:
+        exit(1)
     for p in compiled_packages:
         shutil.copy(p, pypi)
 

--- a/manage-packages
+++ b/manage-packages
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 """
 Version 0.5
 

--- a/manage-packages
+++ b/manage-packages
@@ -87,8 +87,15 @@ _cached_bucket = None
 def aws_bucket():
     global _cached_bucket
     if _cached_bucket is None:
-        conn = boto.connect_s3(AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY)
-        _cached_bucket = conn.get_bucket(BUCKET_NAME)
+        conn = boto.connect_s3()
+        bucket = conn.get_bucket(BUCKET_NAME)
+        # Work around failing to upload large files to newly-created buckets by
+        # connecting directly to the bucket region.
+        bucket_location = bucket.get_location()
+        if bucket_location:
+            conn = boto.s3.connect_to_region(bucket_location)
+            bucket = conn.get_bucket(BUCKET_NAME)
+        _cached_bucket = bucket
     return _cached_bucket
 
 def push_to_s3(key, file):

--- a/manage-packages
+++ b/manage-packages
@@ -28,8 +28,8 @@ except ImportError:
 from boto.s3.key import Key
 
 # Non-sheepdoggers:  change to your bucket
-BUCKET_NAME = 'sheepdog-assets'
-CHEESESHOP_DIR = "feta" # Sheep milk cheese...
+BUCKET_NAME = os.environ.get('PYPI_MIRROR_BUCKET', 'sheepdog-assets')
+CHEESESHOP_DIR = os.environ.get('PYPI_MIRROR_DIR', 'feta')
 
 # Try to provide some level of awscli compatibility
 if 'AWS_CONFIG_FILE' in os.environ:

--- a/manage-packages
+++ b/manage-packages
@@ -27,13 +27,13 @@ except ImportError:
 
 from boto.s3.key import Key
 
-# Make sure you have these set up in your environment
-AWS_SECRET_ACCESS_KEY = os.environ['AWS_SECRET_ACCESS_KEY']
-AWS_ACCESS_KEY_ID = os.environ['AWS_ACCESS_KEY_ID']
-
 # Non-sheepdoggers:  change to your bucket
 BUCKET_NAME = 'sheepdog-assets'
 CHEESESHOP_DIR = "feta" # Sheep milk cheese...
+
+# Try to provide some level of awscli compatibility
+if 'AWS_CONFIG_FILE' in os.environ:
+    boto.config.read(os.environ['AWS_CONFIG_FILE'])
 
 def is_compressed(filename):
     # Just a quick sanity check by filename.  Good enough.


### PR DESCRIPTION
Hi, is there anyone still out there? :-)

If so, here's a few tweaks and improvements:
1. Don't hard-code the path to python. This lets `manage-packages` run in an activated virtualenv.
2. Avoid installing binary files and wheels. The current script ignores them, and I'd rather not have platform-specific gunk on the mirror.
3. Terminate immediately if `pip install -d` fails.
